### PR TITLE
Add doxygen as traget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,3 +96,10 @@ add_subdirectory(tools/pp)
 
 # Build executable
 add_hpx_executable(NLMech SOURCES src/main.cpp DEPENDENCIES Inp Model)
+
+# Build documentation
+set(Enable_Documentation FALSE CACHE BOOL "Generates target for generating the documentation")
+if(${Enable_Documentation})
+add_subdirectory(docs)
+endif()
+

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -5,14 +5,11 @@
 
 find_package(Doxygen)
 
+configure_file(conf.doxy.in ${CMAKE_CURRENT_SOURCE_DIR}/conf.doxy @ONLY)
+
 add_custom_target(doc
         COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile} conf.doxy
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM)
 
-add_custom_target(doc_develop
-        COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile} conf_develop.doxy
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
-        COMMENT "Generating API documentation for development purpose with Doxygen"
-        VERBATIM)

--- a/docs/conf.doxy.in
+++ b/docs/conf.doxy.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "NLMech"
+PROJECT_NAME           = @CMAKE_PROJECT_NAME@
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version


### PR DESCRIPTION
1. -DEnable_Documentation=ON enables the documentation 
2. make doc compiles the documentation
3. We use the project name from cmake within doxygen