### PR TITLE
Add version number to the mesh executable

### DIFF
--- a/tools/mesh/mesh.cpp
+++ b/tools/mesh/mesh.cpp
@@ -6,6 +6,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <Config.h>
+
 #include <algorithm>
 #include <boost/program_options.hpp>
 #include <iostream>
@@ -45,7 +47,9 @@ int main(int argc, char *argv[]) {
   }
 
   if (found != 2) {
-    std::cerr << argv[0] << " -i input.yaml -d 1" << std::endl;
+    std::cerr << argv[0]  << " (Version " << MAJOR_VERSION << "."
+              << MINOR_VERSION << "." << UPDATE_VERSION
+              << ")" << " -i input.yaml -d 1" << std::endl;
     exit(1);
   }
 


### PR DESCRIPTION
The mesh executable shows the version numbers

```diehlpk@xwing build]$ tools/mesh/mesh 
tools/mesh/mesh (Version 0.1.0) -i input.yaml -d 1
```
