### PR TITLE
Add debug postfix to the libaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ configure_file (
   "${PROJECT_SOURCE_DIR}/src/Config.h"
   )
 
+# Add a postfix if the libraries are build in the debug mode
+set(CMAKE_DEBUG_POSTFIX d)
+
 #Enable ctest
 enable_testing()
 


### PR DESCRIPTION
If the code is build in the debug mode, a `d` is added to the lib names, so one can distinguish between release and debug builds. 
