### PR TITLE
Add cmake options to the documentation

### DIFF
--- a/docs/conf.doxy.in
+++ b/docs/conf.doxy.in
@@ -810,6 +810,7 @@ INPUT                  = ../src/main.cpp \
                          ../src/test \
                          ../tools/pp \
                          ../tools/mesh \
+                         ../docs/content/cmake-options.md \
                          ../README.md 
                          
 

--- a/docs/content/cmake-options.md
+++ b/docs/content/cmake-options.md
@@ -1,0 +1,13 @@
+# CMake options
+
+## NLMech 
+
+* Enable_Documentation : Generates target for generating the documentation (Default = False)
+* Enable_Tools : Enables the tools to the build target (Default = False)
+* Enable_Expensive_Tests : Enables the computation intense tests (Default = False)
+
+## General options
+
+* CMAKE_BUILD_TYPE : Specifies the build type (Default = Release)
+
+


### PR DESCRIPTION
Add the cmake options to the documentation, so users can see what kind of options they can use to configure the code. 