### PR TITLE
Fix the wrong output number after restart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,21 +3,22 @@
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-cmake_minimum_required(VERSION 3.10)
 
 #####################################################################
 # Setup 
 #####################################################################
+project(NLMech
+    DESCRIPTION "Framework for non-local mechanics"
+    LANGUAGES CXX)
 
 # Set the version 
 set (VERSION_MAJOR 0)
 set (VERSION_MINOR 1)
 set (VERSION_UPDATE 0)
 
-project(NLMech 
-    VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_UPDATE}
-    DESCRIPTION "Framework for non-local mechanics"
-    LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.10)
+
+
 
 # Provide the configuration file to get the version
 configure_file (

--- a/examples/fdModel/restart/input.yaml
+++ b/examples/fdModel/restart/input.yaml
@@ -1,0 +1,52 @@
+Model:
+  Dimension: 2
+  Discretization_Type:
+    Spatial: finite_difference
+    Time: velocity_verlet
+  Final_Time: 0.0000001
+  Time_Steps: 5
+  Horizon: 0.002000
+  Horizon_h_Ratio: 4
+Policy:
+  Enable_PostProcessing: true
+Mesh:
+  File: mesh.vtu
+  Keep_Element_Conn: true
+Material:
+  Type: PDBond
+  Density: 1200.000000
+  Compute_From_Classical: true
+  E: 3240000000.000000
+  Gc: 500.000000
+  Bond_Potential:
+    Type: 1
+    Check_Sc_Factor: 10.0
+    Irreversible_Bond_Fracture: true
+  Influence_Function:
+    Type: 1
+Force_BC:
+  Sets: 1
+  Set_1:
+    Location:
+      Rectangle: [0, 0, 0.1, 0.002]
+    Direction: [2]
+    Time_Function:
+      Type: linear
+      Parameters:
+        - -5000000000.0
+      Parameters: [1]
+    Spatial_Function:
+      Type: constant
+      Parameters: [1]
+Output:
+  Path: ./
+  Tags:
+    - Displacement
+    - Velocity
+    - Force
+    - Damage_Z
+  Output_Interval: 1
+  Compress_Type: zlib
+  Perform_FE_Out: true
+HPX:
+  Partitions: 1

--- a/examples/fdModel/restart/input_compare.yaml
+++ b/examples/fdModel/restart/input_compare.yaml
@@ -1,0 +1,12 @@
+Dimension: 2
+Filename_1: output_5.vtu
+Filename_2: restart_output_5.vtu
+# output filename with path
+Out_Filename: compare.txt
+# set false if do not want to print result to std::cout
+Print_Screen: true
+# Tolerance for the l2 norm
+Tolerance: 1e-7
+# provide list of tags for which comparison has to be made
+Compare_Tags:
+    - Displacement

--- a/examples/fdModel/restart/input_mesh.yaml
+++ b/examples/fdModel/restart/input_mesh.yaml
@@ -1,0 +1,9 @@
+Output:
+  Path: .
+  Mesh: mesh
+  File_Format: vtu
+Domain: [0.000000e+00, 0.000000e+00, 1.000000e-01, 1.000000e-01]
+Horizon: 2.000000e-03
+Horizon_h_Ratio: 4
+Mesh_Type: uniform_tri
+Compress_Type: zlib

--- a/examples/fdModel/restart/restart.yaml
+++ b/examples/fdModel/restart/restart.yaml
@@ -1,0 +1,55 @@
+Model:
+  Dimension: 2
+  Discretization_Type:
+    Spatial: finite_difference
+    Time: velocity_verlet
+  Final_Time: 0.0000001
+  Time_Steps: 5
+  Horizon: 0.002000
+  Horizon_h_Ratio: 4
+Policy:
+  Enable_PostProcessing: true
+Mesh:
+  File: mesh.vtu
+  Keep_Element_Conn: true
+Material:
+  Type: PDBond
+  Density: 1200.000000
+  Compute_From_Classical: true
+  E: 3240000000.000000
+  Gc: 500.000000
+  Bond_Potential:
+    Type: 1
+    Check_Sc_Factor: 10.0
+    Irreversible_Bond_Fracture: true
+  Influence_Function:
+    Type: 1
+Force_BC:
+  Sets: 1
+  Set_1:
+    Location:
+      Rectangle: [0, 0, 0.1, 0.002]
+    Direction: [2]
+    Time_Function:
+      Type: linear
+      Parameters:
+        - -5000000000.0
+      Parameters: [1]
+    Spatial_Function:
+      Type: constant
+      Parameters: [1]
+Output:
+  Path: ./restart_
+  Tags:
+    - Displacement
+    - Velocity
+    - Force
+    - Damage_Z
+  Output_Interval: 1
+  Compress_Type: zlib
+  Perform_FE_Out: true
+Restart:
+  File: ./output_4.vtu  
+  Step: 4
+HPX:
+  Partitions: 1

--- a/src/model/util.cpp
+++ b/src/model/util.cpp
@@ -3,6 +3,10 @@
 
 model::Output::Output(inp::Input *d_input_p, data::DataManager *d_dataManager_p,
                       size_t d_n, double d_time) {
+
+  if  (d_input_p->getModelDeck()->d_isRestartActive)
+    d_n +=  d_input_p->getRestartDeck()->d_step;
+
   std::cout << "Output: time step = " << d_n << "\n";
 
   // write out % completion of simulation at 10% interval

--- a/src/model/util.cpp
+++ b/src/model/util.cpp
@@ -4,10 +4,6 @@
 model::Output::Output(inp::Input *d_input_p, data::DataManager *d_dataManager_p,
                       size_t d_n, double d_time) {
 
-  std::cout << d_n << std::endl;
-
-  if  (d_input_p->getModelDeck()->d_isRestartActive)
-    d_n +=  d_input_p->getRestartDeck()->d_step * 500;
 
   std::cout << "Output: time step = " << d_n << "\n";
 

--- a/src/model/util.cpp
+++ b/src/model/util.cpp
@@ -4,8 +4,10 @@
 model::Output::Output(inp::Input *d_input_p, data::DataManager *d_dataManager_p,
                       size_t d_n, double d_time) {
 
+  std::cout << d_n << std::endl;
+
   if  (d_input_p->getModelDeck()->d_isRestartActive)
-    d_n +=  d_input_p->getRestartDeck()->d_step;
+    d_n +=  d_input_p->getRestartDeck()->d_step * 500;
 
   std::cout << "Output: time step = " << d_n << "\n";
 

--- a/src/model/util.h
+++ b/src/model/util.h
@@ -15,6 +15,7 @@
 #include "inp/decks/modelDeck.h"
 #include "inp/decks/outputDeck.h"
 #include "inp/decks/policyDeck.h"
+#include "inp/decks/restartDeck.h"
 #include "rw/writer.h"
 #include "data/DataManager.h"
 #include "fe/mesh.h"
@@ -28,6 +29,7 @@ struct ModelDeck;
 struct OutputDeck;
 struct MeshDeck;
 struct PolicyDeck;
+struct RestartDeck;
 class Policy;
 } // namespace inp
 

--- a/src/rw/writer.cpp
+++ b/src/rw/writer.cpp
@@ -216,7 +216,8 @@ void rw::writer::Writer::close() {
     d_legacyVtkWriter_p->close();
 }
 
-inline void rw::writer::Writer::checkLength(const size_t length, const std::string &name) {
+inline void rw::writer::Writer::checkLength(const size_t length,
+                                            const std::string &name) {
   if (length == 0) {
     std::cerr << "Warning: Output field " << name << " is empty!" << std::endl;
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,3 +95,39 @@ WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/qsModel/1D
 # Depencies
 set_tests_properties(quasistatic.1D.elastic_legacy_vtk PROPERTIES
   FIXTURES_SETUP quasistatic.1D.elastic.mesh)
+
+##############################################################################
+# Restart
+##############################################################################
+
+add_test(NAME explicit.restart.mesh
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/mesh -i input_mesh.yaml -d 2
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/fdModel/restart
+)
+
+add_test(NAME explicit.restart.run
+COMMAND ${EXECUTABLE_OUTPUT_PATH}/NLMech -i input.yaml --hpx:threads=1
+WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/fdModel/restart
+)
+
+add_test(NAME explicit.restart.restart
+COMMAND ${EXECUTABLE_OUTPUT_PATH}/NLMech -i restart.yaml --hpx:threads=1
+WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/fdModel/restart
+)
+
+
+add_test(NAME explicit.restart.compare
+COMMAND ${EXECUTABLE_OUTPUT_PATH}/dc -i input_compare.yaml -k fd_simple
+WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/examples/fdModel/restart
+)
+
+
+# Depencies
+set_tests_properties(explicit.restart.run PROPERTIES
+  FIXTURES_SETUP explicit.restart.mesh)
+
+set_tests_properties(explicit.restart.restart PROPERTIES
+  FIXTURES_SETUP explicit.restart.run)
+
+  set_tests_properties(explicit.restart.compare PROPERTIES
+  FIXTURES_SETUP explicit.restart.restart)


### PR DESCRIPTION
After a restart, the output files are numbered with zero again and overwrite the existing files. This fix adds the restart file number and the file numbers are correct again.
