### PR TITLE
Stop the code if the msh file is not there

### DIFF
--- a/src/model/util.cpp
+++ b/src/model/util.cpp
@@ -3,8 +3,6 @@
 
 model::Output::Output(inp::Input *d_input_p, data::DataManager *d_dataManager_p,
                       size_t d_n, double d_time) {
-
-
   std::cout << "Output: time step = " << d_n << "\n";
 
   // write out % completion of simulation at 10% interval

--- a/src/rw/reader.cpp
+++ b/src/rw/reader.cpp
@@ -10,6 +10,7 @@
 #include "csv.h"
 #include "mshReader.h"
 #include "vtkReader.h"
+#include "util.h"
 
 void rw::reader::readCsvFile(const std::string &filename, size_t dim,
                              std::vector<util::Point3> *nodes,
@@ -60,6 +61,11 @@ void rw::reader::readVtuFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
+
+
+  // Check if file exists
+  fileExists(filename);
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   rdr.readMesh(dim, nodes, element_type, num_elem, enc, nec, volumes, is_fd);
@@ -98,6 +104,10 @@ void rw::reader::readVtuFileNodes(const std::string &filename, size_t dim,
 
 bool rw::reader::vtuHasPointData(const std::string &filename,
                                  const std::string &tag) {
+
+  // Check if file exists
+  fileExists(filename);
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto has_data = rdr.vtuHasPointData(tag);
@@ -107,6 +117,10 @@ bool rw::reader::vtuHasPointData(const std::string &filename,
 
 bool rw::reader::vtuHasCellData(const std::string &filename,
                                 const std::string &tag) {
+
+  // Check if file exists
+  fileExists(filename);
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto has_data = rdr.vtuHasCellData(tag);
@@ -116,6 +130,10 @@ bool rw::reader::vtuHasCellData(const std::string &filename,
 
 std::vector<std::string> rw::reader::readVtuFilePointTags(
     const std::string &filename) {
+
+  // Check if file exists
+  fileExists(filename);
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto data = rdr.readVtuFilePointTags();
@@ -125,6 +143,10 @@ std::vector<std::string> rw::reader::readVtuFilePointTags(
 
 std::vector<std::string> rw::reader::readVtuFileCellTags(
     const std::string &filename) {
+  
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto data = rdr.readVtuFileCellTags();
@@ -136,6 +158,9 @@ void rw::reader::readVtuFileCells(const std::string &filename, size_t dim,
                                   size_t &element_type, size_t &num_elem,
                                   std::vector<size_t> *enc,
                                   std::vector<std::vector<size_t>> *nec) {
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
 
@@ -149,6 +174,10 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
+  
+  // Check if file exists
+  fileExists(filename);
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // if displacement is not in input file, use reference coordinate to get
@@ -174,6 +203,10 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<uint8_t> *data) {
+  
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -185,6 +218,10 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<size_t> *data) {
+  
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -196,6 +233,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<int> *data) {
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -207,6 +247,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<float> *data) {
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -218,6 +261,10 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
+  
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -229,6 +276,10 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Point3> *data) {
+  
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -240,6 +291,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::SymMatrix3> *data) {
+  // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -251,6 +305,10 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Matrix33> *data) {
+  
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -262,6 +320,10 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<float> *data) {
+    // Check if file exists
+  fileExists(filename);
+  
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -273,6 +335,9 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<double> *data) {
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -284,6 +349,10 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Point3> *data) {
+  
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -295,6 +364,10 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::SymMatrix3> *data) {
+  
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -306,6 +379,9 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Matrix33> *data) {
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -320,6 +396,10 @@ void rw::reader::readMshFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
+  
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
   rdr.readMesh(dim, nodes, element_type, num_elem, enc, nec, volumes, is_fd);
@@ -330,6 +410,10 @@ void rw::reader::readMshFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
+  
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
   // if displacement is not in input file, use reference coordinate to get
@@ -355,6 +439,10 @@ void rw::reader::readMshFileRestart(const std::string &filename,
 bool rw::reader::readMshFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
+  
+    // Check if file exists
+  fileExists(filename);
+  
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // get velocity

--- a/src/rw/reader.cpp
+++ b/src/rw/reader.cpp
@@ -61,8 +61,6 @@ void rw::reader::readVtuFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
-  // Check if file exists
-  fileExists(filename);
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -102,8 +100,6 @@ void rw::reader::readVtuFileNodes(const std::string &filename, size_t dim,
 
 bool rw::reader::vtuHasPointData(const std::string &filename,
                                  const std::string &tag) {
-  // Check if file exists
-  fileExists(filename);
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -114,8 +110,6 @@ bool rw::reader::vtuHasPointData(const std::string &filename,
 
 bool rw::reader::vtuHasCellData(const std::string &filename,
                                 const std::string &tag) {
-  // Check if file exists
-  fileExists(filename);
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -126,8 +120,7 @@ bool rw::reader::vtuHasCellData(const std::string &filename,
 
 std::vector<std::string> rw::reader::readVtuFilePointTags(
     const std::string &filename) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -138,8 +131,7 @@ std::vector<std::string> rw::reader::readVtuFilePointTags(
 
 std::vector<std::string> rw::reader::readVtuFileCellTags(
     const std::string &filename) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -152,8 +144,7 @@ void rw::reader::readVtuFileCells(const std::string &filename, size_t dim,
                                   size_t &element_type, size_t &num_elem,
                                   std::vector<size_t> *enc,
                                   std::vector<std::vector<size_t>> *nec) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -168,8 +159,7 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
-  // Check if file exists
-  fileExists(filename);
+  
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -196,8 +186,6 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<uint8_t> *data) {
-  // Check if file exists
-  fileExists(filename);
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -210,8 +198,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<size_t> *data) {
-  // Check if file exists
-  fileExists(filename);
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -224,8 +210,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<int> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -238,8 +223,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<float> *data) {
-  // Check if file exists
-  fileExists(filename);
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -252,8 +235,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -266,8 +248,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Point3> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -280,8 +261,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::SymMatrix3> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -294,8 +274,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Matrix33> *data) {
-  // Check if file exists
-  fileExists(filename);
+  
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -308,8 +287,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<float> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -322,8 +300,7 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<double> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -336,8 +313,7 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Point3> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -350,8 +326,7 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::SymMatrix3> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -364,8 +339,6 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Matrix33> *data) {
-  // Check if file exists
-  fileExists(filename);
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
@@ -381,8 +354,7 @@ void rw::reader::readMshFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
-  // Check if file exists
-  fileExists(filename);
+  
 
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
@@ -394,8 +366,7 @@ void rw::reader::readMshFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
-  // Check if file exists
-  fileExists(filename);
+ 
 
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
@@ -422,8 +393,7 @@ void rw::reader::readMshFileRestart(const std::string &filename,
 bool rw::reader::readMshFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
-  // Check if file exists
-  fileExists(filename);
+
 
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);

--- a/src/rw/reader.cpp
+++ b/src/rw/reader.cpp
@@ -61,7 +61,6 @@ void rw::reader::readVtuFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   rdr.readMesh(dim, nodes, element_type, num_elem, enc, nec, volumes, is_fd);
@@ -100,7 +99,6 @@ void rw::reader::readVtuFileNodes(const std::string &filename, size_t dim,
 
 bool rw::reader::vtuHasPointData(const std::string &filename,
                                  const std::string &tag) {
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto has_data = rdr.vtuHasPointData(tag);
@@ -110,7 +108,6 @@ bool rw::reader::vtuHasPointData(const std::string &filename,
 
 bool rw::reader::vtuHasCellData(const std::string &filename,
                                 const std::string &tag) {
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto has_data = rdr.vtuHasCellData(tag);
@@ -120,8 +117,6 @@ bool rw::reader::vtuHasCellData(const std::string &filename,
 
 std::vector<std::string> rw::reader::readVtuFilePointTags(
     const std::string &filename) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto data = rdr.readVtuFilePointTags();
@@ -131,8 +126,6 @@ std::vector<std::string> rw::reader::readVtuFilePointTags(
 
 std::vector<std::string> rw::reader::readVtuFileCellTags(
     const std::string &filename) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto data = rdr.readVtuFileCellTags();
@@ -144,8 +137,6 @@ void rw::reader::readVtuFileCells(const std::string &filename, size_t dim,
                                   size_t &element_type, size_t &num_elem,
                                   std::vector<size_t> *enc,
                                   std::vector<std::vector<size_t>> *nec) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
 
@@ -159,8 +150,6 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
-  
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // if displacement is not in input file, use reference coordinate to get
@@ -186,7 +175,6 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<uint8_t> *data) {
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -198,7 +186,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<size_t> *data) {
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -210,8 +197,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<int> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -223,7 +208,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<float> *data) {
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -235,8 +219,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -248,8 +230,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Point3> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -261,8 +241,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::SymMatrix3> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -274,8 +252,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Matrix33> *data) {
-  
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -287,8 +263,6 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<float> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -300,8 +274,6 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<double> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -313,8 +285,6 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Point3> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -326,8 +296,6 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::SymMatrix3> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -339,7 +307,6 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Matrix33> *data) {
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -354,8 +321,6 @@ void rw::reader::readMshFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
-  
-
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
   rdr.readMesh(dim, nodes, element_type, num_elem, enc, nec, volumes, is_fd);
@@ -366,8 +331,6 @@ void rw::reader::readMshFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
- 
-
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
   // if displacement is not in input file, use reference coordinate to get
@@ -393,8 +356,6 @@ void rw::reader::readMshFileRestart(const std::string &filename,
 bool rw::reader::readMshFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
-
-
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // get velocity

--- a/src/rw/reader.cpp
+++ b/src/rw/reader.cpp
@@ -61,8 +61,6 @@ void rw::reader::readVtuFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
-
-
   // Check if file exists
   fileExists(filename);
 
@@ -104,7 +102,6 @@ void rw::reader::readVtuFileNodes(const std::string &filename, size_t dim,
 
 bool rw::reader::vtuHasPointData(const std::string &filename,
                                  const std::string &tag) {
-
   // Check if file exists
   fileExists(filename);
 
@@ -117,7 +114,6 @@ bool rw::reader::vtuHasPointData(const std::string &filename,
 
 bool rw::reader::vtuHasCellData(const std::string &filename,
                                 const std::string &tag) {
-
   // Check if file exists
   fileExists(filename);
 
@@ -130,7 +126,6 @@ bool rw::reader::vtuHasCellData(const std::string &filename,
 
 std::vector<std::string> rw::reader::readVtuFilePointTags(
     const std::string &filename) {
-
   // Check if file exists
   fileExists(filename);
 
@@ -143,10 +138,9 @@ std::vector<std::string> rw::reader::readVtuFilePointTags(
 
 std::vector<std::string> rw::reader::readVtuFileCellTags(
     const std::string &filename) {
-  
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   auto data = rdr.readVtuFileCellTags();
@@ -160,7 +154,7 @@ void rw::reader::readVtuFileCells(const std::string &filename, size_t dim,
                                   std::vector<std::vector<size_t>> *nec) {
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
 
@@ -174,7 +168,6 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
-  
   // Check if file exists
   fileExists(filename);
 
@@ -203,10 +196,9 @@ void rw::reader::readVtuFileRestart(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<uint8_t> *data) {
-  
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -218,10 +210,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<size_t> *data) {
-  
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -233,9 +224,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<int> *data) {
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -249,7 +240,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       std::vector<float> *data) {
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -261,10 +252,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
-  
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -276,10 +266,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Point3> *data) {
-  
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -293,7 +282,7 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       std::vector<util::SymMatrix3> *data) {
   // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -305,10 +294,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<util::Matrix33> *data) {
-  
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -320,10 +308,9 @@ bool rw::reader::readVtuFilePointData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<float> *data) {
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -335,9 +322,9 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<double> *data) {
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -349,10 +336,9 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Point3> *data) {
-  
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -364,10 +350,9 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::SymMatrix3> *data) {
-  
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -379,9 +364,9 @@ bool rw::reader::readVtuFileCellData(const std::string &filename,
 bool rw::reader::readVtuFileCellData(const std::string &filename,
                                      const std::string &tag,
                                      std::vector<util::Matrix33> *data) {
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // read data
@@ -396,10 +381,9 @@ void rw::reader::readMshFile(const std::string &filename, size_t dim,
                              std::vector<size_t> *enc,
                              std::vector<std::vector<size_t>> *nec,
                              std::vector<double> *volumes, bool is_fd) {
-  
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
   rdr.readMesh(dim, nodes, element_type, num_elem, enc, nec, volumes, is_fd);
@@ -410,10 +394,9 @@ void rw::reader::readMshFileRestart(const std::string &filename,
                                     std::vector<util::Point3> *u,
                                     std::vector<util::Point3> *v,
                                     const std::vector<util::Point3> *X) {
-  
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::MshReader(filename);
   // if displacement is not in input file, use reference coordinate to get
@@ -439,10 +422,9 @@ void rw::reader::readMshFileRestart(const std::string &filename,
 bool rw::reader::readMshFilePointData(const std::string &filename,
                                       const std::string &tag,
                                       std::vector<double> *data) {
-  
-    // Check if file exists
+  // Check if file exists
   fileExists(filename);
-  
+
   // call vtk reader
   auto rdr = rw::reader::VtkReader(filename);
   // get velocity

--- a/src/rw/util.cpp
+++ b/src/rw/util.cpp
@@ -26,5 +26,3 @@ std::string rw::getDataType(const std::string &data_name) {
 
   return "";
 }
-
-}

--- a/src/rw/util.cpp
+++ b/src/rw/util.cpp
@@ -17,8 +17,6 @@ std::vector<std::string> get_point_tags() {
   return {"Displacement", "Velocity", "Force", "Force_Density"};
 }
 
-
-
 std::string rw::getDataType(const std::string &data_name) {
   for (const auto &tag : get_double_tags())
     if (data_name == tag) return "double";
@@ -30,13 +28,10 @@ std::string rw::getDataType(const std::string &data_name) {
 }
 
 bool rw::fileExists(std::string file_name) {
-
   bool result = boost::filesystem::exists(file_name);
 
-  if (! result) {
-
+  if (!result) {
     std::cerr << "Error: File " + file_name + " not found!";
     std::exit(1);
-  } 
-
+  }
 }

--- a/src/rw/util.cpp
+++ b/src/rw/util.cpp
@@ -27,11 +27,4 @@ std::string rw::getDataType(const std::string &data_name) {
   return "";
 }
 
-bool rw::fileExists(std::string file_name) {
-  bool result = boost::filesystem::exists(file_name);
-
-  if (!result) {
-    std::cerr << "Error: File " + file_name + " not found!";
-    std::exit(1);
-  }
 }

--- a/src/rw/util.cpp
+++ b/src/rw/util.cpp
@@ -8,8 +8,6 @@
 
 #include "util.h"
 
-namespace {
-
 std::vector<std::string> get_double_tags() {
   return {"Damage",       "Damage_Phi", "Damage_Z",  "Node_Volume",
           "Nodal_Volume", "Fixity",     "Work_Done", "Strain_Energy"};
@@ -19,7 +17,7 @@ std::vector<std::string> get_point_tags() {
   return {"Displacement", "Velocity", "Force", "Force_Density"};
 }
 
-}  // namespace
+
 
 std::string rw::getDataType(const std::string &data_name) {
   for (const auto &tag : get_double_tags())
@@ -29,4 +27,16 @@ std::string rw::getDataType(const std::string &data_name) {
     if (data_name == tag) return "point";
 
   return "";
+}
+
+bool rw::fileExists(std::string file_name) {
+
+  bool result = boost::filesystem::exists(file_name);
+
+  if (! result) {
+
+    std::cerr << "Error: File " + file_name + " not found!";
+    std::exit(1);
+  } 
+
 }

--- a/src/rw/util.h
+++ b/src/rw/util.h
@@ -17,11 +17,19 @@ namespace rw {
 
 
 /*!
-* @brief Returnd the data type
+* @brief Returns the data type
 * @param  data_name Name of the data element
 * @return The data type
 */
 std::string getDataType(const std::string &data_name);
+
+/*!
+* @brief checks if the file exists 
+* @param file_name The path and name to the file to be checked
+* @return True if the file exists and False if not
+*/
+
+bool fileExists(std::string file_name);
 
 } // namespace rw
 

--- a/src/rw/util.h
+++ b/src/rw/util.h
@@ -29,8 +29,6 @@ std::string getDataType(const std::string &data_name);
 * @return True if the file exists and False if not
 */
 
-bool fileExists(std::string file_name);
-
 } // namespace rw
 
 #endif // RW_UTIL_H

--- a/src/rw/vtkReader.cpp
+++ b/src/rw/vtkReader.cpp
@@ -20,6 +20,7 @@
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnsignedIntArray.h>
 #include <vtkVersion.h>
+#include <vtkErrorCode.h>
 
 #include "util/feElementDefs.h"
 
@@ -27,6 +28,16 @@ size_t rw::reader::VtkReader::d_count = 0;
 
 rw::reader::VtkReader::VtkReader(const std::string &filename) {
   d_count++;
+
+  std::ifstream d_myfile;
+  d_myfile.open(filename);
+
+    if (!d_myfile.is_open()) {
+    std::cerr << "Error: Could not open or generate following file: " << filename
+              << std::endl;
+              std::exit(1);
+  }
+  d_myfile.close();
 
   // Append the extension vtu to file_name
   d_reader_p = vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();

--- a/src/rw/vtkReader.cpp
+++ b/src/rw/vtkReader.cpp
@@ -32,10 +32,10 @@ rw::reader::VtkReader::VtkReader(const std::string &filename) {
   std::ifstream d_myfile;
   d_myfile.open(filename);
 
-    if (!d_myfile.is_open()) {
-    std::cerr << "Error: Could not open or generate following file: " << filename
-              << std::endl;
-              std::exit(1);
+  if (!d_myfile.is_open()) {
+    std::cerr << "Error: Could not open or generate following file: "
+              << filename << std::endl;
+    std::exit(1);
   }
   d_myfile.close();
 


### PR DESCRIPTION


## Proposed Changes

  - If there is no mesh.vtu file on the file system, but specified in the YAML file, the code runs with no discrete nodes
  - Now the code stops and prints the error message. 

## Any background context you want to provide?
